### PR TITLE
Widen parser-combinators version bounds

### DIFF
--- a/medea.cabal
+++ b/medea.cabal
@@ -69,7 +69,7 @@ library
     , microlens-ghc         ^>=0.4.12
     , mtl                   ^>=2.2.2
     , nonempty-containers   ^>=0.3.3.0
-    , parser-combinators    ^>=1.1.0
+    , parser-combinators    >=1.1.0    && <2.0.0
     , scientific            ^>=0.3.6.2
     , text                  ^>=1.2.3.1
     , unordered-containers  ^>=0.2.10.0


### PR DESCRIPTION
This is necessary to have support for being on Stackage; the original
bounds were too restrictive, as it ruled out version 1.2.1.