### PR TITLE
Carry around our conformance suite

### DIFF
--- a/medea.cabal
+++ b/medea.cabal
@@ -23,6 +23,7 @@ extra-source-files:
   README.md
   SPEC.md
   TUTORIAL.md
+  conformance/*
 
 source-repository head
   type:     git


### PR DESCRIPTION
Without this being in the package, we can't have Medea be on Stackage,
as the tests fail to run out of an unpacked sdist. To be honest, we
should probably carry this around _anyway_, because as it currently
stands, people who get Medea off an sdist can't even run the tests.